### PR TITLE
Skill Competition: Formatting and update Ben's contact email

### DIFF
--- a/_site/tools/index.html
+++ b/_site/tools/index.html
@@ -206,38 +206,39 @@
                     <h2 class="text-success">Skill Classification Competition</h2>
                     
                     <h4>Competition Overview</h4>
-                    <p>The 2026 competition consists of building and assessing multi‑label classifiers that predict, for each issue, the set of domains and sub‑domains representing the skills required to solve it.</p>
+                    <p>The 2026 competition consists of building and assessing multi-label classifiers that predict, for each issue, the set of domains and sub-domains representing the skills required to solve it.</p>
 
                     <h4>Dataset</h4>
-                    <p>We release a dataset mined from 7,245 merged pull requests across 11 popular Java repositories (57,206 source files; 59,644 methods; 13,097 classes) annotated with 217 skill labels composed by domain/sub‑domains. The full corpus (inputs and gold‑labels) is shipped as an SQLite database (skillscope_data.db) for easy reproducibility.</p>
+                    <p>We release a dataset mined from 7,245 merged pull requests across 11 popular Java repositories (57,206 source files; 59,644 methods; 13,097 classes) annotated with 217 skill labels composed by domain/sub-domains. The full corpus (inputs and gold-labels) is shipped as an SQLite database (skillscope_data.db) for easy reproducibility.</p>
 
+                    <h5>Ready Made Tables:</h5>
+                    <p>Inside the database you will find a table named nlbse_tool_competition_data_by_issue that joins each pull request's textual and code-context features with its canonical domain/sub-domain labels per issue. There is also a view vw_nlbse_tool_competition_data_by_file that labels each filename/function associated with each issue.</p>
                     <ul>
-                      <li><code>Ready-made Table</code>: Inside the database you will find a table named nlbse_tool_competition_data_by_issue that joins each pull request's textual and code‑context features with its canonical domain/sub‑domain labels per issue. There is also a view vw_nlbse_tool_competition_data_by_file that labels each filename/function associated with each issue.</li>
                       <li>The <code>nlbse_tool_competition_data_by_issue</code> table contains a column for each domain and subdomain with an integer count of the number of matching APIs found for that issue. A value greater than zero indicates that domain/subdomain is present in the issue.</li>
                       <li>The <code>vw_nlbse_tool_competition_data_by_file</code> is present for convenience purposes only and will not be used in evaluation of the model.</li>
                     </ul>
 
-                    <p>The dataset can be found in our <a href="https://github.com/nlbse2026/skill-classification" target="_blank">Github repository</a>.</p>
+                    <p>The dataset can be found on <a href="https://huggingface.co/datasets/NLBSE/SkillCompetition" target="_blank">huggingface</a>.</p>
 
-                    <h4>Additional Data Usage</h4>
+                    <h5>Additional Data Usage</h5>
                     <p>Your model is allowed to use input data that is outside what is given in the database. You may use additional GitHub APIs to fetch more metadata, or download relevant files in an issue for further analysis. However, you must not use any third-party classification engine or the outputs present in <code>skillscope_data.db</code> as direct inputs to the model.</p>
 
-                    <h4>Baselines</h4>
-                    <p>Your models will be compared against the SkillScope Random‑Forest + TF‑IDF baselines reported in the paper by evaluating the overall prediction metrics against the issue classifications as recorded in the <code>nlbse_tool_competition_data_by_issue</code> table. The models you create should return a multi-label classification encoded in an one-hot encoded vector. However, it is the metrics of your models which will be the subject to the evaluation instead of the specific model output. </p>
+                    <h5>Baselines</h5>
+                    <p>Your models will be compared against the SkillScope Random-Forest + TF-IDF baselines reported in the paper by evaluating the overall prediction metrics against the issue classifications as recorded in the <code>nlbse_tool_competition_data_by_issue</code> table. The models you create should return a multi-label classification encoded in an one-hot encoded vector. However, it is the metrics of your models which will be the subject to the evaluation instead of the specific model output. </p>
 
-                    <h4>Goal</h4>
-                    <p>Train, tune, and evaluate your models and improve at least one of precision, recall, or micro‑F1 while not decreasing the remaining metrics relative to the SkillScope baseline.</p>
+                    <h5>Goal</h5>
+                    <p>Train, tune, and evaluate your models and improve at least one of precision, recall, or micro-F1 while not decreasing the remaining metrics relative to the SkillScope baseline.</p>
 
                     <h4>Competition Organizers</h4>
-                    <p>The skill classification competition is organized by: <b>Fabio Santos</b> (fabio.deabreusantos), <b>Benjamin Carter</b> (BCarter44@my.gcu.edu), and <b>Jacob Penney</b> (jmp458@nau.edu).</p>
+                    <p>The skill classification competition is organized by: <b>Fabio Santos</b> (fabio.deabreusantos), <b>Benjamin Carter</b> (benjamincarter@ucsb.edu), and <b>Jacob Penney</b> (jmp458@nau.edu).</p>
 
                     <h4>Submission Acceptance & Competition</h4>
-                    <p>Submissions will first be filtered to ensure they do not lower any of the three core metrics (<strong>precision</strong>, <strong>recall</strong>, <strong>micro‑F1</strong>) compared with the baseline. Among qualifying submissions, ranking is determined by the largest positive improvement in micro‑F1. Ties will be broken by (1) precision, then (2) runtime.</p>
+                    <p>Submissions will first be filtered to ensure they do not lower any of the three core metrics (<strong>precision</strong>, <strong>recall</strong>, <strong>micro-F1</strong>) compared with the baseline. Among qualifying submissions, ranking is determined by the largest positive improvement in micro-F1. Ties will be broken by (1) precision, then (2) runtime.</p>
 
                     <p>Submissions will be judged on:</p>
                     <ul>
                         <li>Clarity and completeness of the paper.</li>
-                        <li>Availability and reproducibility of code/tool (open‑source required).</li>
+                        <li>Availability and reproducibility of code/tool (open-source required).</li>
                         <li>Correct use of the provided data split.</li>
                         <li>Correct reporting of metrics.</li>
                         <li>Quality of documentation.</li>
@@ -245,10 +246,10 @@
 
                     <p>Accepted papers will appear in the <strong>NLBSE '26 proceedings</strong>.</p>
 
-                    <h4>Ranking Details</h4>
-                    <p>Participants submit a single multi‑label classifier. Rankings proceed in two stages:</p>
+                    <h5>Ranking Details</h5>
+                    <p>Participants submit a single multi-label classifier. Rankings proceed in two stages:</p>
                     <ol>
-                        <li><strong>Eligibility check:</strong> The submission must not reduce any of precision, recall, or micro‑F1 compared with the baseline.</li>
+                        <li><strong>Eligibility check:</strong> The submission must not reduce any of precision, recall, or micro-F1 compared with the baseline.</li>
                         <li><strong>Ordering:</strong> Qualifying submissions are ordered by the greatest positive ∆micro‑F1.</li>
                     </ol>
                 </div>
@@ -256,8 +257,7 @@
                 <div style="text-align: left;">
                 <h3>Citing Relevant Work</h3>
 
-                <h4>General Competition Citation</h4>
-                <p>Please cite if participating:</p>
+                <h4>General Competition Citation:</h4>
                 <pre><code class="language-tex">@inproceedings{nlbse2026,
   author = {Moritz Mock and Rani, Pooja and Santos, Fabio and Carter, Benjamin and Penney, Jacob},
   title={The NLBSE'26 Tool Competition},
@@ -304,7 +304,7 @@
     number       = {},
     pages        = {9--12},
     doi          = {10.1109/NLBSE66842.2025.00007},
-    keywords     = {Radio frequency;Training;Java;Large language models;Semantics;Retrieval augmented generation;Machine learning;Open source software;Software engineering;Software development management;software engineering;skill categorization;open source software (OSS);machine learning;large language models}
+    keywords     = {Random Forest;Training;Java;Large language models;Semantics;Retrieval augmented generation;Machine learning;Open source software;Software engineering;Software development management;software engineering;skill categorization;open source software (OSS);machine learning;large language models}
 }</code></pre>
 
                 <pre><code class="language-tex">@article{santos2023tag,

--- a/tools/index.html
+++ b/tools/index.html
@@ -71,38 +71,39 @@ title: Tool Competitions
                     <h2 class="text-success">Skill Classification Competition</h2>
                     
                     <h4>Competition Overview</h4>
-                    <p>The 2026 competition consists of building and assessing multi‑label classifiers that predict, for each issue, the set of domains and sub‑domains representing the skills required to solve it.</p>
+                    <p>The 2026 competition consists of building and assessing multi-label classifiers that predict, for each issue, the set of domains and sub-domains representing the skills required to solve it.</p>
 
                     <h4>Dataset</h4>
-                    <p>We release a dataset mined from 7,245 merged pull requests across 11 popular Java repositories (57,206 source files; 59,644 methods; 13,097 classes) annotated with 217 skill labels composed by domain/sub‑domains. The full corpus (inputs and gold‑labels) is shipped as an SQLite database (skillscope_data.db) for easy reproducibility.</p>
+                    <p>We release a dataset mined from 7,245 merged pull requests across 11 popular Java repositories (57,206 source files; 59,644 methods; 13,097 classes) annotated with 217 skill labels composed by domain/sub-domains. The full corpus (inputs and gold-labels) is shipped as an SQLite database (skillscope_data.db) for easy reproducibility.</p>
 
+                    <h5>Ready Made Tables:</h5>
+                    <p>Inside the database you will find a table named <code>nlbse_tool_competition_data_by_issue</code> that joins each pull request's textual and code-context features with its canonical domain/sub-domain labels per issue. There is also a view <code>vw_nlbse_tool_competition_data_by_file</code> that labels each filename/function associated with each issue.</p>
                     <ul>
-                      <li><code>Ready-made Table</code>: Inside the database you will find a table named nlbse_tool_competition_data_by_issue that joins each pull request's textual and code‑context features with its canonical domain/sub‑domain labels per issue. There is also a view vw_nlbse_tool_competition_data_by_file that labels each filename/function associated with each issue.</li>
                       <li>The <code>nlbse_tool_competition_data_by_issue</code> table contains a column for each domain and subdomain with an integer count of the number of matching APIs found for that issue. A value greater than zero indicates that domain/subdomain is present in the issue.</li>
                       <li>The <code>vw_nlbse_tool_competition_data_by_file</code> is present for convenience purposes only and will not be used in evaluation of the model.</li>
                     </ul>
 
-                    <p>The dataset can be found in our <a href="https://github.com/nlbse2026/skill-classification" target="_blank">Github repository</a>.</p>
+                    <p>The dataset can be found on <a href="https://huggingface.co/datasets/NLBSE/SkillCompetition" target="_blank">huggingface</a>.</p>
 
-                    <h4>Additional Data Usage</h4>
+                    <h5>Additional Data Usage</h5>
                     <p>Your model is allowed to use input data that is outside what is given in the database. You may use additional GitHub APIs to fetch more metadata, or download relevant files in an issue for further analysis. However, you must not use any third-party classification engine or the outputs present in <code>skillscope_data.db</code> as direct inputs to the model.</p>
 
-                    <h4>Baselines</h4>
-                    <p>Your models will be compared against the SkillScope Random‑Forest + TF‑IDF baselines reported in the paper by evaluating the overall prediction metrics against the issue classifications as recorded in the <code>nlbse_tool_competition_data_by_issue</code> table. The models you create should return a multi-label classification encoded in an one-hot encoded vector. However, it is the metrics of your models which will be the subject to the evaluation instead of the specific model output. </p>
+                    <h5>Baselines</h5>
+                    <p>Your models will be compared against the SkillScope Random-Forest + TF-IDF baselines reported in the paper by evaluating the overall prediction metrics against the issue classifications as recorded in the <code>nlbse_tool_competition_data_by_issue</code> table. The models you create should return a multi-label classification encoded in an one-hot encoded vector. However, it is the metrics of your models which will be the subject to the evaluation instead of the specific model output. </p>
 
-                    <h4>Goal</h4>
-                    <p>Train, tune, and evaluate your models and improve at least one of precision, recall, or micro‑F1 while not decreasing the remaining metrics relative to the SkillScope baseline.</p>
+                    <h5>Goal</h5>
+                    <p>Train, tune, and evaluate your models and improve at least one of precision, recall, or micro-F1 while not decreasing the remaining metrics relative to the SkillScope baseline.</p>
 
                     <h4>Competition Organizers</h4>
-                    <p>The skill classification competition is organized by: <b>Fabio Santos</b> (fabio.deabreusantos), <b>Benjamin Carter</b> (BCarter44@my.gcu.edu), and <b>Jacob Penney</b> (jmp458@nau.edu).</p>
+                    <p>The skill classification competition is organized by: <b>Fabio Santos</b> (fabio.deabreusantos), <b>Benjamin Carter</b> (benjamincarter@ucsb.edu), and <b>Jacob Penney</b> (jmp458@nau.edu).</p>
 
                     <h4>Submission Acceptance & Competition</h4>
-                    <p>Submissions will first be filtered to ensure they do not lower any of the three core metrics (<strong>precision</strong>, <strong>recall</strong>, <strong>micro‑F1</strong>) compared with the baseline. Among qualifying submissions, ranking is determined by the largest positive improvement in micro‑F1. Ties will be broken by (1) precision, then (2) runtime.</p>
+                    <p>Submissions will first be filtered to ensure they do not lower any of the three core metrics (<strong>precision</strong>, <strong>recall</strong>, <strong>micro-F1</strong>) compared with the baseline. Among qualifying submissions, ranking is determined by the largest positive improvement in micro-F1. Ties will be broken by (1) precision, then (2) runtime.</p>
 
                     <p>Submissions will be judged on:</p>
                     <ul>
                         <li>Clarity and completeness of the paper.</li>
-                        <li>Availability and reproducibility of code/tool (open‑source required).</li>
+                        <li>Availability and reproducibility of code/tool (open-source required).</li>
                         <li>Correct use of the provided data split.</li>
                         <li>Correct reporting of metrics.</li>
                         <li>Quality of documentation.</li>
@@ -110,10 +111,10 @@ title: Tool Competitions
 
                     <p>Accepted papers will appear in the <strong>NLBSE '26 proceedings</strong>.</p>
 
-                    <h4>Ranking Details</h4>
-                    <p>Participants submit a single multi‑label classifier. Rankings proceed in two stages:</p>
+                    <h5>Ranking Details</h5>
+                    <p>Participants submit a single multi-label classifier. Rankings proceed in two stages:</p>
                     <ol>
-                        <li><strong>Eligibility check:</strong> The submission must not reduce any of precision, recall, or micro‑F1 compared with the baseline.</li>
+                        <li><strong>Eligibility check:</strong> The submission must not reduce any of precision, recall, or micro-F1 compared with the baseline.</li>
                         <li><strong>Ordering:</strong> Qualifying submissions are ordered by the greatest positive ∆micro‑F1.</li>
                     </ol>
                 </div>
@@ -121,8 +122,7 @@ title: Tool Competitions
                 <div style="text-align: left;">
                 <h3>Citing Relevant Work</h3>
 
-                <h4>General Competition Citation</h4>
-                <p>Please cite if participating:</p>
+                <h4>General Competition Citation:</h4>
                 <pre><code class="language-tex">@inproceedings{nlbse2026,
   author = {Moritz Mock and Rani, Pooja and Santos, Fabio and Carter, Benjamin and Penney, Jacob},
   title={The NLBSE'26 Tool Competition},
@@ -169,7 +169,7 @@ title: Tool Competitions
     number       = {},
     pages        = {9--12},
     doi          = {10.1109/NLBSE66842.2025.00007},
-    keywords     = {Radio frequency;Training;Java;Large language models;Semantics;Retrieval augmented generation;Machine learning;Open source software;Software engineering;Software development management;software engineering;skill categorization;open source software (OSS);machine learning;large language models}
+    keywords     = {Random Forest;Training;Java;Large language models;Semantics;Retrieval augmented generation;Machine learning;Open source software;Software engineering;Software development management;software engineering;skill categorization;open source software (OSS);machine learning;large language models}
 }</code></pre>
 
                 <pre><code class="language-tex">@article{santos2023tag,


### PR DESCRIPTION
Extends commit 6f640f0.
- Moved institutions, so now I (Ben) am using my ucsb email.
- The "Ready-Made-Table" behaves as a section instead of a bullet list.
- Replaced non-standard en-dashes with ascii minus signs for the SkillCompetition portion.
- Changed to link to huggingface for dataset.